### PR TITLE
normalizing the log group name

### DIFF
--- a/src/ecs.js
+++ b/src/ecs.js
@@ -22,7 +22,13 @@ exports.handler = function(event, context, callback){
         var paperTrailPort = config.port;
     }
 
-    var nameParts = data.logGroup.split('/').pop().split('-')
+    // Some of the log groups are named like `ecs/environment-application-service`,
+    // some with a leading slash like `/ecs/environment-application-service`, and
+    // some with the service after a slash like `/ecs/environment-application/service`.
+    // This normalizes them, extracting the environment, application, and service.
+    var logGroupName = data.logGroup.replace(/^\/?ecs\//, '');
+    var nameParts = logGroupName.split(/[-\/]/)
+
     var env = nameParts[0]
     var app = nameParts[1]
     var service = nameParts[2]

--- a/src/syslog.js
+++ b/src/syslog.js
@@ -20,7 +20,13 @@ exports.handler = function(event, context, callback){
         var syslogPort = config.port;
     }
 
-    var nameParts = data.logGroup.split('/').pop().split('-')
+    // Some of the log groups are named like `ecs/environment-application-service`,
+    // some with a leading slash like `/ecs/environment-application-service`, and
+    // some with the service after a slash like `/ecs/environment-application/service`.
+    // This normalizes them, extracting the environment, application, and service.
+    var logGroupName = data.logGroup.replace(/^\/?ecs\//, '');
+    var nameParts = logGroupName.split(/[-\/]/)
+
     var env = nameParts[0]
     var app = nameParts[1]
     var service = nameParts[2]


### PR DESCRIPTION
Some services log groups are named with a different convention. This PR updates the parsing of the log group name, to determine the environment, application, and service, for any of the (current) conventions.