### PR TITLE
bringing code from published production lambda

### DIFF
--- a/src/lambda.js
+++ b/src/lambda.js
@@ -28,7 +28,7 @@ exports.handler = function(event, context, callback){
       host: paperTrailHost,
       port: paperTrailPort,
       hostname: "Lambda_" + data.owner + "_" + process.env.AWS_REGION,
-      program: data.logGroup.split('/').pop(),
+      program: data.logGroup.split('/').pop().split('-').slice(0, -1).join('-'),
       logFormat: function(level, message){
         return message;
       }


### PR DESCRIPTION
The LambdaLogConsumer code had been published in AWS, but the changes had not been committed to the repo. Before making any further changes, we're bringing this update into history.